### PR TITLE
Feature hide join button and tab for committee groups

### DIFF
--- a/hc-custom.php
+++ b/hc-custom.php
@@ -20,7 +20,6 @@ require_once trailingslashit( __DIR__ ) . 'includes/mla-groups.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-group-email-subscription.php';
 require_once trailingslashit( __DIR__ ) . 'includes/siteorigin-panels.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-followers.php';
-require_once trailingslashit( __DIR__ ) . 'includes/buddypress-group-members.php';
 require_once trailingslashit( __DIR__ ) . 'includes/cbox-auth.php';
 
 

--- a/hc-custom.php
+++ b/hc-custom.php
@@ -20,4 +20,8 @@ require_once trailingslashit( __DIR__ ) . 'includes/mla-groups.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-group-email-subscription.php';
 require_once trailingslashit( __DIR__ ) . 'includes/siteorigin-panels.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-followers.php';
+require_once trailingslashit( __DIR__ ) . 'includes/buddypress-group-members.php';
+require_once trailingslashit( __DIR__ ) . 'includes/cbox-auth.php';
+
+
 

--- a/includes/cbox-auth.php
+++ b/includes/cbox-auth.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Customizations to cbox-auth plugin
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Get object property or return default value.
+ *
+ * @param object $obj      Object.
+ * @param string $property Property name.
+ * @param mixed  $default  Default value.
+ * @return mixed Property value or default value.
+ */
+function get_object_property( $obj, string $property, $default ) {
+	return ( property_exists( $obj, $property ) ) ? $obj->$property : $default;
+}
+
+	/**
+	 * Get group type.
+	 */
+function get_group_type() {
+	global $groups_template;
+
+	if ( $groups_template && get_object_property( $groups_template, 'group', false ) ) {
+		$bp_id = $groups_template->group->id;
+		return strtolower( \groups_get_groupmeta( $bp_id, 'society_group_type', true ) );
+	}
+
+	return 0;
+}
+
+	/**
+	 * Hide the join/leave button for committees and forums for which the
+	 * user is not an admin.
+	 *
+	 * @param BP_Groups_Group $group BuddyPress group.
+	 */
+function hide_join_button( $group ) {
+
+		$user_id = \bp_loggedin_user_id();
+		$group_type = get_group_type();
+
+		// Remove the other actions that would create this button.
+		$actions = array(
+		'bp_group_header_actions'     => 'bp_group_join_button',
+		'bp_directory_groups_actions' => 'bp_group_join_button',
+		);
+		foreach ( $actions as $name => $action ) {
+			\remove_action( $name, $action, \has_action( $name, $action ) );
+		}
+
+		$is_committee   = ( 'committee' === $group_type );
+		$is_forum_admin = ( 'forum' === $group_type && \groups_is_user_admin( $user_id, \bp_get_group_id() ) );
+
+		if ( $is_committee || $is_forum_admin ) {
+			return;
+		}
+
+		return \bp_group_join_button( $group );
+}
+
+	add_action( 'bp_group_header_actions', 'hide_join_button', 1 );
+	add_action( 'bp_directory_groups_actions', 'hide_join_button', 1 );
+
+
+	/**
+	 * Hide the request membership tab for committees.
+	 *
+	 * @param string $string Unchanged filter string.
+	 */
+function hide_request_membership_tab( string $string ) {
+	return ( 'committee' === get_group_type() ) ? null : $string;
+}
+
+	add_filter( 'bp_get_options_nav_request-membership', 'hide_request_membership_tab' );
+
+
+
+
+

--- a/includes/cbox-auth.php
+++ b/includes/cbox-auth.php
@@ -13,7 +13,7 @@
  * @param mixed  $default  Default value.
  * @return mixed Property value or default value.
  */
-function get_object_property( $obj, string $property, $default ) {
+function get_object_property( $obj, $property, $default ) {
 	return ( property_exists( $obj, $property ) ) ? $obj->$property : $default;
 }
 
@@ -58,20 +58,22 @@ function hide_join_button( $group ) {
 		return;
 	}
 
-	return \bp_group_join_button( $group );
+	if ( class_exists( 'Humanities_Commons' ) && 'mla' !== Humanities_Commons::$society_id ) {
+		return \bp_group_join_button( $group );
+	}
 }
 
-add_action( 'bp_group_header_actions', 'hide_join_button', 1 );
-add_action( 'bp_directory_groups_actions', 'hide_join_button', 1 );
+add_action( 'bp_group_header_actions', 'hide_join_button', 1);
+add_action( 'bp_directory_groups_actions', 'hide_join_button', 1);
 
 /**
  * Hide the request membership tab for committees.
  *
  * @param string $string Unchanged filter string.
  */
-function hide_request_membership_tab( string $string ) {
+function hide_request_membership_tab ( $string ) {
 	return ( 'committee' === get_group_type() ) ? null : $string;
 }
 
-add_filter( 'bp_get_options_nav_request-membership', 'hide_request_membership_tab' );
+add_filter( 'bp_get_options_nav_request-membership', 'hide_request_membership_tab');
 

--- a/includes/cbox-auth.php
+++ b/includes/cbox-auth.php
@@ -13,17 +13,17 @@
  * @param mixed  $default  Default value.
  * @return mixed Property value or default value.
  */
-function get_object_property( $obj, $property, $default ) {
+function hc_custom_get_object_property( $obj, $property, $default ) {
 	return ( property_exists( $obj, $property ) ) ? $obj->$property : $default;
 }
 
 /**
 * Get group type.
 */
-function get_group_type() {
+function hc_custom_get_group_type() {
 	global $groups_template;
 
-	if ( $groups_template && get_object_property( $groups_template, 'group', false ) ) {
+	if ( $groups_template && hc_custom_get_object_property( $groups_template, 'group', false ) ) {
 		$bp_id = $groups_template->group->id;
 		return strtolower( \groups_get_groupmeta( $bp_id, 'society_group_type', true ) );
 	}
@@ -37,10 +37,10 @@ function get_group_type() {
  *
  * @param BP_Groups_Group $group BuddyPress group.
  */
-function hide_join_button( $group ) {
+function hc_custom_hide_join_button( $group ) {
 
 	$user_id = \bp_loggedin_user_id();
-	$group_type = get_group_type();
+	$group_type = hc_custom_get_group_type();
 
 	// Remove the other actions that would create this button.
 	$actions = array(
@@ -63,17 +63,17 @@ function hide_join_button( $group ) {
 	}
 }
 
-add_action( 'bp_group_header_actions', 'hide_join_button', 1);
-add_action( 'bp_directory_groups_actions', 'hide_join_button', 1);
+add_action( 'bp_group_header_actions', 'hc_custom_hide_join_button', 1);
+add_action( 'bp_directory_groups_actions', 'hc_custom_hide_join_button', 1);
 
 /**
  * Hide the request membership tab for committees.
  *
  * @param string $string Unchanged filter string.
  */
-function hide_request_membership_tab ( $string ) {
-	return ( 'committee' === get_group_type() ) ? null : $string;
+function hc_custom_hide_request_membership_tab ( $string ) {
+	return ( 'committee' === hc_custom_get_group_type() ) ? null : $string;
 }
 
-add_filter( 'bp_get_options_nav_request-membership', 'hide_request_membership_tab');
+add_filter( 'bp_get_options_nav_request-membership', 'hc_custom_hide_request_membership_tab');
 

--- a/includes/cbox-auth.php
+++ b/includes/cbox-auth.php
@@ -18,8 +18,8 @@ function get_object_property( $obj, string $property, $default ) {
 }
 
 /**
- * Get group type.
- */
+* Get group type.
+*/
 function get_group_type() {
 	global $groups_template;
 
@@ -64,7 +64,6 @@ function hide_join_button( $group ) {
 add_action( 'bp_group_header_actions', 'hide_join_button', 1 );
 add_action( 'bp_directory_groups_actions', 'hide_join_button', 1 );
 
-
 /**
  * Hide the request membership tab for committees.
  *
@@ -75,8 +74,4 @@ function hide_request_membership_tab( string $string ) {
 }
 
 add_filter( 'bp_get_options_nav_request-membership', 'hide_request_membership_tab' );
-
-
-
-
 

--- a/includes/cbox-auth.php
+++ b/includes/cbox-auth.php
@@ -17,9 +17,9 @@ function get_object_property( $obj, string $property, $default ) {
 	return ( property_exists( $obj, $property ) ) ? $obj->$property : $default;
 }
 
-	/**
-	 * Get group type.
-	 */
+/**
+ * Get group type.
+ */
 function get_group_type() {
 	global $groups_template;
 
@@ -31,50 +31,50 @@ function get_group_type() {
 	return 0;
 }
 
-	/**
-	 * Hide the join/leave button for committees and forums for which the
-	 * user is not an admin.
-	 *
-	 * @param BP_Groups_Group $group BuddyPress group.
-	 */
+/**
+ * Hide the join/leave button for committees and forums for which the
+ * user is not an admin.
+ *
+ * @param BP_Groups_Group $group BuddyPress group.
+ */
 function hide_join_button( $group ) {
 
-		$user_id = \bp_loggedin_user_id();
-		$group_type = get_group_type();
+	$user_id = \bp_loggedin_user_id();
+	$group_type = get_group_type();
 
-		// Remove the other actions that would create this button.
-		$actions = array(
-		'bp_group_header_actions'     => 'bp_group_join_button',
-		'bp_directory_groups_actions' => 'bp_group_join_button',
-		);
-		foreach ( $actions as $name => $action ) {
-			\remove_action( $name, $action, \has_action( $name, $action ) );
-		}
+	// Remove the other actions that would create this button.
+	$actions = array(
+	'bp_group_header_actions'     => 'bp_group_join_button',
+	'bp_directory_groups_actions' => 'bp_group_join_button',
+	);
+	foreach ( $actions as $name => $action ) {
+		\remove_action( $name, $action, \has_action( $name, $action ) );
+	}
 
-		$is_committee   = ( 'committee' === $group_type );
-		$is_forum_admin = ( 'forum' === $group_type && \groups_is_user_admin( $user_id, \bp_get_group_id() ) );
+	$is_committee   = ( 'committee' === $group_type );
+	$is_forum_admin = ( 'forum' === $group_type && \groups_is_user_admin( $user_id, \bp_get_group_id() ) );
 
-		if ( $is_committee || $is_forum_admin ) {
-			return;
-		}
+	if ( $is_committee || $is_forum_admin ) {
+		return;
+	}
 
-		return \bp_group_join_button( $group );
+	return \bp_group_join_button( $group );
 }
 
-	add_action( 'bp_group_header_actions', 'hide_join_button', 1 );
-	add_action( 'bp_directory_groups_actions', 'hide_join_button', 1 );
+add_action( 'bp_group_header_actions', 'hide_join_button', 1 );
+add_action( 'bp_directory_groups_actions', 'hide_join_button', 1 );
 
 
-	/**
-	 * Hide the request membership tab for committees.
-	 *
-	 * @param string $string Unchanged filter string.
-	 */
+/**
+ * Hide the request membership tab for committees.
+ *
+ * @param string $string Unchanged filter string.
+ */
 function hide_request_membership_tab( string $string ) {
 	return ( 'committee' === get_group_type() ) ? null : $string;
 }
 
-	add_filter( 'bp_get_options_nav_request-membership', 'hide_request_membership_tab' );
+add_filter( 'bp_get_options_nav_request-membership', 'hide_request_membership_tab' );
 
 
 


### PR DESCRIPTION
Taking hide join button and tab for committees functions from cbox plugin and adding a more general version of these functions for all societies. 

See:
https://trello.com/c/GwtSXZf7/292-treat-society-committees-differently-from-other-groups-follow-the-mla-access-and-group-type-model