### PR TITLE
Hiding root blogs from site directory

### DIFF
--- a/hc-custom.php
+++ b/hc-custom.php
@@ -21,5 +21,5 @@ require_once trailingslashit( __DIR__ ) . 'includes/buddypress-group-email-subsc
 require_once trailingslashit( __DIR__ ) . 'includes/siteorigin-panels.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-followers.php';
 require_once trailingslashit( __DIR__ ) . 'includes/cbox-auth.php';
-require_once trailingslashit( __DIR__ ) . 'includes/buddypress-site-directory.php';
+require_once trailingslashit( __DIR__ ) . 'includes/buddypress-sites.php';
 

--- a/hc-custom.php
+++ b/hc-custom.php
@@ -21,5 +21,5 @@ require_once trailingslashit( __DIR__ ) . 'includes/buddypress-group-email-subsc
 require_once trailingslashit( __DIR__ ) . 'includes/siteorigin-panels.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-followers.php';
 require_once trailingslashit( __DIR__ ) . 'includes/cbox-auth.php';
-
+require_once trailingslashit( __DIR__ ) . 'includes/buddypress-site-directory.php';
 

--- a/includes/buddypress-site-directory.php
+++ b/includes/buddypress-site-directory.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Customizations to buddypress site directory.
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Filter the sites query by latest post, exclude blogs with none
+ *
+ * @param array $args Includes the string of blog ids.
+ * @return array $args
+ */
+function hcommons_exclude_no_latest_post( $args ) {
+	global $wpdb;
+
+	$blog_ids = explode( ',', $args['include_blog_ids'] );
+
+	foreach ( $blog_ids  as $blog_id ) {
+		$blog_prefix = $wpdb->get_blog_prefix( $blog_id );
+		$latest_post = $wpdb->get_row( "SELECT ID FROM {$blog_prefix}posts WHERE post_status = 'publish' AND post_type = 'post' AND id != 1 ORDER BY id DESC LIMIT 1" );
+
+		if ( null === $latest_post ) {
+			$blog_ids = array_diff( $blog_ids, array( $blog_id ) );
+		}
+	}
+
+	if ( ! empty( $blog_ids ) ) {
+		$include_blogs = implode( ',', $blog_ids );
+		$args['include_blog_ids'] = $include_blogs;
+	}
+
+	return $args;
+}
+
+add_filter( 'bp_before_has_blogs_parse_args', 'hcommons_exclude_root_blogs', 999 );
+

--- a/includes/buddypress-site-directory.php
+++ b/includes/buddypress-site-directory.php
@@ -33,5 +33,5 @@ function hcommons_exclude_no_latest_post( $args ) {
 	return $args;
 }
 
-add_filter( 'bp_before_has_blogs_parse_args', 'hcommons_exclude_root_blogs', 999 );
+add_filter( 'bp_before_has_blogs_parse_args', 'hcommons_exclude_no_latest_post', 999 );
 

--- a/includes/buddypress-sites.php
+++ b/includes/buddypress-sites.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Customizations to buddypress site directory.
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Filter the sites query, exclude root blogs from query.
+ *
+ * @param array $args Includes the string of blog ids.
+ * @return array $args
+ */
+function hcommons_exclude_root_blogs( $args ) {
+
+	$blog_ids = explode( ',', $args['include_blog_ids'] );
+
+	foreach ( get_networks() as $network ) {
+		$blog_id = get_main_site_id( $network->id );
+		$blog_ids = array_diff( $blog_ids, array( $blog_id ) );
+	}
+
+	if ( ! empty( $blog_ids ) ) {
+		$include_blogs = implode( ',', $blog_ids );
+		$args['include_blog_ids'] = $include_blogs;
+	}
+
+	return $args;
+}
+
+add_filter( 'bp_before_has_blogs_parse_args', 'hcommons_exclude_root_blogs', 999 );
+


### PR DESCRIPTION
Using get_networks and get_main_site_id to get the root blogs.

See https://trello.com/c/Dr6LaUme/250-hide-root-blogs-from-site-directory