### PR TITLE
Removing image button

### DIFF
--- a/includes/bbpress.php
+++ b/includes/bbpress.php
@@ -70,7 +70,7 @@ add_filter( 'bbp_get_forum_subscribe_link', '__return_false' );
  */
 function hcommons_tinymce_buttons( $buttons ) {
 
-	if ( bp_is_group_forum_topic() ) {
+	if ( bp_is_group() ) {
 		// Remove image button.
 		$remove = array( 'image' );
 		$buttons = array_diff( $buttons, $remove );


### PR DESCRIPTION
This modification ensures the image button is also removed from the "create topic" form. 

https://trello.com/c/H3D9jF9f/306-remove-insert-image-button-from-discussion-forum-wysiwyg-editor