### PR TITLE
Update group email settings

### DIFF
--- a/includes/buddypress-group-email-subscription.php
+++ b/includes/buddypress-group-email-subscription.php
@@ -453,7 +453,7 @@ add_action( 'bp_notification_settings', 'hc_custom_group_forum_subscription_sett
 function hc_custom_default_group_forum_subscription_settings() {
 	global $bp;
 
-	$user_id = $bp->displayed_user->id;
+	$user_id   = $bp->displayed_user->id;
 	$my_status = get_user_meta( $user_id, 'default_group_notifications', true );
 ?>
 
@@ -461,12 +461,12 @@ function hc_custom_default_group_forum_subscription_settings() {
 		<thead>
 			<tr>
 				<th class="icon"></th>
-				<th class="title"><?php _e( 'Default Notifications For New Groups', 'group_forum_subscription' ) ?></th>
-				<th class="no-email gas-choice"><?php _e( 'No Email', 'buddypress' ) ?></th>
-				<th class="weekly gas-choice"><?php _e( 'Weekly Summary', 'buddypress' )?></th>
-				<th class="daily gas-choice"><?php _e( 'Daily Digest', 'buddypress' )?></th>
-				<th class="new-topics gas-choice"><?php _e( 'New Topics', 'buddypress' )?></th>
-				<th class="all-email gas-choice"><?php _e( 'All Email', 'buddypress' )?></th>
+				<th class="title"><?php _e( 'Default Notifications For New Groups', 'group_forum_subscription' ); ?></th>
+				<th class="no-email gas-choice"><?php _e( 'No Email', 'buddypress' ); ?></th>
+				<th class="weekly gas-choice"><?php _e( 'Weekly Summary', 'buddypress' ); ?></th>
+				<th class="daily gas-choice"><?php _e( 'Daily Digest', 'buddypress' ); ?></th>
+				<th class="new-topics gas-choice"><?php _e( 'New Topics', 'buddypress' ); ?></th>
+				<th class="all-email gas-choice"><?php _e( 'All Email', 'buddypress' ); ?></th>
 
 			</tr>
 		</thead>
@@ -477,27 +477,43 @@ function hc_custom_default_group_forum_subscription_settings() {
 			<td></td>
 
 			<td>
-				<a href="<?php bp_group_permalink() ?>"><?php bp_group_name() ?></a>
+				<a href="<?php bp_group_permalink(); ?>"><?php bp_group_name(); ?></a>
 			</td>
 
 			<td class="no-email gas-choice">
-				<input type="radio" name="default-group-notifications" value="no" <?php if ( 'no' == $my_status || ! $my_status ) { ?>checked="checked" <?php } ?>/>
+				<input type="radio" name="default-group-notifications" value="no"
+				<?php if ( 'no' == $my_status || ! $my_status ) { ?>
+					checked="checked"
+				<?php } ?>/>
 			</td>
 
 			<td class="weekly gas-choice">
-				<input type="radio" name="default-group-notifications" value="sum" <?php if ( 'sum' == $my_status ) { ?>checked="checked" <?php } ?>/>
+				<input type="radio" name="default-group-notifications" value="sum" 
+				<?php
+				if ( 'sum' == $my_status ) {
+?>
+checked="checked" <?php } ?>/>
 			</td>
 
 			<td class="daily gas-choice">
-				<input type="radio" name="default-group-notifications" value="dig" <?php if ( 'dig' == $my_status ) { ?>checked="checked" <?php } ?>/>
+				<input type="radio" name="default-group-notifications" value="dig"
+				<?php if ( 'dig' == $my_status ) { ?>
+					checked="checked"
+				<?php } ?>/>
 			</td>
 
 			<td class="new-topics gas-choice">
-				<input type="radio" name="default-group-notifications" value="sub" <?php if ( 'sub' == $my_status ) { ?>checked="checked" <?php } ?>/>
+				<input type="radio" name="default-group-notifications" value="sub"
+				<?php if ( 'sub' == $my_status ) { ?>
+					checked="checked"
+				<?php } ?>/>
 			</td>
 
 			<td class="weekly gas-choice">
-				<input type="radio" name="default-group-notifications" value="supersub" <?php if ( 'supersub' == $my_status ) { ?>checked="checked" <?php } ?>/>
+				<input type="radio" name="default-group-notifications" value="supersub"
+				<?php if ( 'supersub' == $my_status ) { ?>
+					checked="checked"
+				<?php } ?>/>
 			</td>
 		</tr>
 <?php
@@ -527,9 +543,9 @@ function hc_custom_update_group_subscribe_settings() {
 
 	if ( isset( $_POST['default-group-notifications'] ) ) {
 		$user_id = bp_loggedin_user_id();
-		$value = $_POST['default-group-notifications'];
+		$value   = $_POST['default-group-notifications'];
 
-		update_user_meta( $user_id, 'default_group_notifications',  $value );
+		update_user_meta( $user_id, 'default_group_notifications', $value );
 	}
 
 }
@@ -659,16 +675,16 @@ function hc_custom_ass_bp_email_footer_html_unsubscribe_links() {
 		unset( buddypress()->ges_tokens );
 }
 
-add_action( 'bp_after_email_footer' , 'hc_custom_ass_bp_email_footer_html_unsubscribe_links' );
+add_action( 'bp_after_email_footer', 'hc_custom_ass_bp_email_footer_html_unsubscribe_links' );
 
 /**
  * Disable the default subscription settings during group creation.
  */
 function hc_custom_disable_subscription_settings_form() {
-	remove_action( 'bp_after_group_settings_creation_step' , 'ass_default_subscription_settings_form' );
+	remove_action( 'bp_after_group_settings_creation_step', 'ass_default_subscription_settings_form' );
 }
 
-add_action( 'bp_after_group_settings_creation_step' ,'hc_custom_disable_subscription_settings_form', 0 );
+add_action( 'bp_after_group_settings_creation_step', 'hc_custom_disable_subscription_settings_form', 0 );
 
 /**
  * Set default notification for user on accept or invite.

--- a/includes/buddypress-group-email-subscription.php
+++ b/includes/buddypress-group-email-subscription.php
@@ -420,7 +420,7 @@ add_action( 'bp_notification_settings', 'hc_custom_group_forum_subscription_sett
 
 
 /**
- * Reproduces email notification settings (as in legacy email system) in Group Activity Subscription
+ * Adds a section for users to set their default group notifications when joining a new group.
  */
 function hc_custom_default_group_forum_subscription_settings() {
 	global $bp;
@@ -508,9 +508,10 @@ function hc_custom_update_group_subscribe_settings() {
 
 add_action( 'bp_actions', 'hc_custom_update_group_subscribe_settings' );
 
-// give the user a notice if they are default subscribed to this group (does not work for invites or requests)
+/**
+ * Give the user a notice if they are default subscribed to this group (does not work for invites or requests).
+ **/
 function hc_custom_join_group_message( $group_id, $user_id ) {
-	global $bp;
 
 	remove_action( 'groups_join_group', 'ass_join_group_message' );
 
@@ -625,11 +626,35 @@ function hc_custom_ass_bp_email_footer_html_unsubscribe_links() {
 
 add_action( 'bp_after_email_footer' , 'hc_custom_ass_bp_email_footer_html_unsubscribe_links' );
 
-// Disable the default subscription settings during group creation and editing.
+/**
+ * Disable the default subscription settings during group creation.
+ */
 function hc_custom_disable_subscription_settings_form() {
-	remove_action( 'bp_after_group_settings_admin' , 'ass_default_subscription_settings_form' );
     remove_action( 'bp_after_group_settings_creation_step' , 'ass_default_subscription_settings_form' );
-
 }
 
 add_action ( 'bp_after_group_settings_creation_step' ,'hc_custom_disable_subscription_settings_form', 0 );
+
+
+/**
+ * Set default notification for user on accept or invite.
+ *
+ * @param int $user_id  ID of the user who joined the group.
+ * @param int $group_id ID of the group the member has joined.
+ */
+function hc_custom_set_notifications_on_accept_invite_or_request( $user_id, $group_id ) {
+
+	if ( $user_id != bp_loggedin_user_id()  )
+		return;
+
+	$status = get_user_meta( $user_id, 'default_group_notifications', true );
+
+	if ( empty( $status ) ) {
+		$status = 'no';
+	}
+
+	ass_group_subscription( $status, $user_id, $group_id );
+}
+
+add_action( 'groups_accept_invite', 'ass_send_welcome_email_on_accept_invite_or_request', 10, 2 );
+add_action( 'groups_membership_accepted', 'ass_send_welcome_email_on_accept_invite_or_request', 10, 2 );

--- a/includes/buddypress-group-email-subscription.php
+++ b/includes/buddypress-group-email-subscription.php
@@ -632,5 +632,4 @@ function hc_custom_disable_subscription_settings_form() {
 
 }
 
-//add_action ( 'bp_after_group_settings_admin' ,'hc_custom_disable_subscription_settings_form', 0);
 add_action ( 'bp_after_group_settings_creation_step' ,'hc_custom_disable_subscription_settings_form', 0 );

--- a/includes/buddypress-group-email-subscription.php
+++ b/includes/buddypress-group-email-subscription.php
@@ -454,7 +454,7 @@ function hc_custom_default_group_forum_subscription_settings() {
 	global $bp;
 
 	$user_id = $bp->displayed_user->id;
-	$my_status = get_user_meta( $user_id, 'default_group_notifications', true);
+	$my_status = get_user_meta( $user_id, 'default_group_notifications', true );
 ?>
 
 	<table class="notification-settings" id="groups-notification-settings">
@@ -529,7 +529,7 @@ function hc_custom_update_group_subscribe_settings() {
 		$user_id = bp_loggedin_user_id();
 		$value = $_POST['default-group-notifications'];
 
-		update_user_meta( $user_id, 'default_group_notifications',  $value);
+		update_user_meta( $user_id, 'default_group_notifications',  $value );
 	}
 
 }
@@ -538,18 +538,22 @@ add_action( 'bp_actions', 'hc_custom_update_group_subscribe_settings' );
 
 /**
  * Give the user a notice if they are default subscribed to this group (does not work for invites or requests).
+ *
+ * @param int $group_id ID of the group the member has joined.
+ * @param int $user_id ID of the user who joined the group.
  **/
 function hc_custom_join_group_message( $group_id, $user_id ) {
 
 	remove_action( 'groups_join_group', 'ass_join_group_message' );
 
-	if ( $user_id != bp_loggedin_user_id()  )
-		return;
+	if ( bp_loggedin_user_id() != $user_id ) {
+		return; }
 
 	$status = get_user_meta( $user_id, 'default_group_notifications', true );
 
 	if ( empty( $status ) ) {
 		$status = 'no';
+		update_user_meta( $user_id, 'default_group_notifications', 'no' );
 	}
 
 	ass_group_subscription( $status, $user_id, $group_id );
@@ -661,10 +665,10 @@ add_action( 'bp_after_email_footer' , 'hc_custom_ass_bp_email_footer_html_unsubs
  * Disable the default subscription settings during group creation.
  */
 function hc_custom_disable_subscription_settings_form() {
-    remove_action( 'bp_after_group_settings_creation_step' , 'ass_default_subscription_settings_form' );
+	remove_action( 'bp_after_group_settings_creation_step' , 'ass_default_subscription_settings_form' );
 }
 
-add_action ( 'bp_after_group_settings_creation_step' ,'hc_custom_disable_subscription_settings_form', 0 );
+add_action( 'bp_after_group_settings_creation_step' ,'hc_custom_disable_subscription_settings_form', 0 );
 
 /**
  * Set default notification for user on accept or invite.
@@ -674,17 +678,15 @@ add_action ( 'bp_after_group_settings_creation_step' ,'hc_custom_disable_subscri
  */
 function hc_custom_set_notifications_on_accept_invite_or_request( $user_id, $group_id ) {
 
-	if ( $user_id != bp_loggedin_user_id()  )
-		return;
-
 	$status = get_user_meta( $user_id, 'default_group_notifications', true );
 
 	if ( empty( $status ) ) {
 		$status = 'no';
+		update_user_meta( $user_id, 'default_group_notifications', 'no' );
 	}
 
 	ass_group_subscription( $status, $user_id, $group_id );
 }
 
-add_action( 'groups_accept_invite', 'ass_send_welcome_email_on_accept_invite_or_request', 10, 2 );
-add_action( 'groups_membership_accepted', 'ass_send_welcome_email_on_accept_invite_or_request', 10, 2 );
+add_action( 'groups_accept_invite', 'hc_custom_set_notifications_on_accept_invite_or_request', 20, 2 );
+add_action( 'groups_membership_accepted', 'hc_custom_set_notifications_on_accept_invite_or_request', 20, 2 );


### PR DESCRIPTION
Updating group email setting, disabling admin control over user group notifications. Giving user the option of setting a default group notifications when joining new groups. 

https://trello.com/c/WS4uiekZ/351-update-group-email-settings