### PR TITLE
What's New Form

### DIFF
--- a/hc-custom.php
+++ b/hc-custom.php
@@ -18,6 +18,7 @@
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-blogs.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-groups.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-members.php';
+require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-activity.php';
 
 /**
  * Plugin actions & filters.

--- a/includes/buddypress/bp-activity.php
+++ b/includes/buddypress/bp-activity.php
@@ -7,14 +7,18 @@
 
 /**
  * Removes the activity form if there is a discussion board.
+ *
+ * @param array  $templates Array of templates located.
+ * @param string $slug      Template part slug requested.
+ * @param string $name      Template part name requested.
  */
 function hc_custom_template_part_filter( $templates, $slug, $name ) {
 
 	if ( 'activity/post-form' !== $slug ) {
-    	return $templates;
-    }
+		return $templates;
+	}
 
-    if( bp_is_group() ) {
+	if ( bp_is_group() ) {
 		$bp = buddypress();
 
 		// Get group forum IDs.

--- a/includes/buddypress/bp-activity.php
+++ b/includes/buddypress/bp-activity.php
@@ -32,6 +32,7 @@ function hc_custom_template_part_filter( $templates, $slug, $name ) {
 		}
 	}
 
+	return $templates;
 }
 
 add_filter( 'bp_get_template_part', 'hc_custom_template_part_filter', 10, 3 );

--- a/includes/buddypress/bp-activity.php
+++ b/includes/buddypress/bp-activity.php
@@ -8,25 +8,26 @@
 /**
  * Removes the activity form if there is a discussion board.
  */
-function hc_custom_bp_before_group_activity_post_form() {
-	$bp = buddypress();
+function hc_custom_template_part_filter( $templates, $slug, $name ) {
 
-	// Get group forum IDs.
-	$forum_ids = bbp_get_group_forum_ids( $group->id );
+	if ( 'activity/post-form' !== $slug ) {
+    	return $templates;
+    }
 
-	// Bail if no forum IDs available.
-	if ( empty( $forum_ids ) ) :
-		return;
-	else :
-?>
-		<style>
-		#whats-new-form {
-		display: none;
+    if( bp_is_group() ) {
+		$bp = buddypress();
+
+		// Get group forum IDs.
+		$forum_ids = bbp_get_group_forum_ids( $group->id );
+
+		// Bail if no forum IDs available.
+		if ( empty( $forum_ids ) ) {
+			return $templates;
+		} else {
+			return false;
 		}
-		</style>
-<?php
+	}
 
-	endif;
 }
 
-add_action( 'bp_before_group_activity_post_form', 'hc_custom_bp_before_group_activity_post_form' );
+add_filter( 'bp_get_template_part', 'hc_custom_template_part_filter', 10, 3 );

--- a/includes/buddypress/bp-activity.php
+++ b/includes/buddypress/bp-activity.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Customizations to BuddyPress Activity.
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Removes the activity form if there is a discussion board.
+ */
+function hc_custom_bp_before_group_activity_post_form() {
+	$bp = buddypress();
+
+	// Get group forum IDs.
+	$forum_ids = bbp_get_group_forum_ids( $group->id );
+
+	// Bail if no forum IDs available.
+	if ( empty( $forum_ids ) ) :
+		return;
+	else :
+?>
+		<style>
+		#whats-new-form {
+		display: none;
+		}
+		</style>
+<?php
+
+	endif;
+}
+
+add_action( 'bp_before_group_activity_post_form', 'hc_custom_bp_before_group_activity_post_form' );


### PR DESCRIPTION
Removing what's new form if the group has a discussion board.

https://trello.com/c/T4c4MRJk/353-remove-whats-new-prompt-on-group-activity-page-when-group-has-discussion-forum