### PR TITLE
Fix For group member search

### DIFF
--- a/hc-custom.php
+++ b/hc-custom.php
@@ -20,6 +20,8 @@ require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-blogs.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-groups.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-members.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-activity.php';
+require_once trailingslashit( __DIR__ ) . 'includes/buddypress/buddypress-functions.php';
+
 
 /**
  * Plugin actions & filters.

--- a/includes/buddypress/buddypress-functions.php
+++ b/includes/buddypress/buddypress-functions.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Customizations to BuddyPress Functions.
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Filters bp_legacy_object_template_path to fix group member directory bug.
+ *
+ * @param string $template_path Template Directory.
+ */
+function hc_custom_bp_legacy_object_template_path( $template_path ) {
+
+	if ( ! empty( $_POST['template'] ) && 'groups/single/members' === $_POST['template'] ) {
+		$template_part = 'groups/single/members.php';
+		$template_path = bp_locate_template( array( $template_part ), false );
+	}
+
+	return $template_path;
+}
+
+add_filter( 'bp_legacy_object_template_path', 'hc_custom_bp_legacy_object_template_path' );


### PR DESCRIPTION
Line 808 of /plugins/buddypress/src/bp-templates/bp-legacy/buddypress-functions.php is checking object variable and loading the correct template if object is "group_members". However, line 856 of buddypress.js is always setting this variable to just "members" causing the wrong template to load. This is fixed in BuddyPress 3.0. This is a temporary filter to fix the issue. 