### PR TITLE
Fixing bp-event-organiser event descriptions

### DIFF
--- a/hc-custom.php
+++ b/hc-custom.php
@@ -31,6 +31,7 @@ require_once trailingslashit( __DIR__ ) . 'includes/bbpress.php';
 require_once trailingslashit( __DIR__ ) . 'includes/bbp-live-preview.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-docs.php';
 require_once trailingslashit( __DIR__ ) . 'includes/bp-groupblog.php';
+require_once trailingslashit( __DIR__ ) . 'includes/bp-event-organiser.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-followers.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-group-email-subscription.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-more-privacy-options.php';

--- a/includes/bp-event-organiser.php
+++ b/includes/bp-event-organiser.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Customizations to bp-event-organiser plugin.
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Callback filter to use BPEO's content for the canonical event page.
+ *
+ * @param  string $content Current content.
+ */
+function hc_custom_filter_bp_event_content( $content ) {
+	global $page;
+
+	$post_type = get_post_type( get_the_ID() );
+
+	if ( 'event' === $post_type ) {
+		$page = 1;
+	}
+
+	return $content;
+}
+
+add_filter( 'the_content', 'hc_custom_filter_bp_event_content' );


### PR DESCRIPTION
get_the_content() is weird and checks the $pages global for the content. Events plugin is incorrectly setting it to zero, so it can't find the content. 

See https://trello.com/c/5thWCzKi/457-bug-events-descriptions-dont-display-when-published