### PR TITLE
Fixing display of group email subscriptin settings

### DIFF
--- a/includes/buddypress-group-email-subscription.php
+++ b/includes/buddypress-group-email-subscription.php
@@ -452,8 +452,8 @@ checked="checked" <?php } ?>/>
 			bp_the_group();
 
 			$group_id       = bp_get_group_id();
-			$subscribers    = groups_get_groupmeta( $group_id, 'ass_subscribed_users' );
 			$user_id        = $bp->displayed_user->id;
+			$subscribers 	= ass_get_subscriptions_for_group( $group_id );
 			$current_status = $subscribers[ $user_id ];
 
 		?>
@@ -902,8 +902,10 @@ function hc_custom_update_group_subscribe_settings() {
 		return false;
 	}
 
+
 	// If the edit form has been submitted, save the edited details.
 	if ( isset( $_POST['group-notifications'] ) ) {
+
 		$user_id = bp_loggedin_user_id();
 
 		foreach ( $_POST['group-notifications'] as $group_id => $value ) {


### PR DESCRIPTION
Fixes broken display of group email settings. Since it's the same function being used here is a pull request for when you want to merge it. 