### PR TITLE
Fix doc attachments

### DIFF
--- a/includes/buddypress-docs.php
+++ b/includes/buddypress-docs.php
@@ -201,6 +201,13 @@ function hc_custom_pre_get_posts( $query ) {
 			$query->set( 'meta_key', 'bp_docs_orderby' );
 		}
 	}
+
+	if ( 'attachment' === $query->get( 'post_type' ) ) {
+		if ( bp_docs_is_bp_docs_page() ) {
+			$query->set( 'posts_per_page', -1 );
+		}
+	}
+
 	return $query;
 }
 


### PR DESCRIPTION
Looks like later versions of buddypress-docs fixed this issue, adding a filter for now, I will create a card to download and test the new Buddypress Docs:

https://github.com/boonebgorges/buddypress-docs/commit/e55356fab380d872cd253f06860078bbc5ce5ad3

For more background:
https://github.com/boonebgorges/buddypress-docs/pull/617