### PR TITLE
Fixing personal message filters

### DIFF
--- a/includes/bbpress.php
+++ b/includes/bbpress.php
@@ -474,10 +474,19 @@ function filter_bbp_current_user_can_access_create_reply_form( $access ) {
 add_filter( 'bbp_current_user_can_access_create_reply_form', 'filter_bbp_current_user_can_access_create_reply_form', 999 );
 
 /**
+ * Return default for buddypress messages spamblocker.
+ * @param int $max The maximum number of emails.
+ */
+function hc_custom_buddypress_messages_spamblocker( $max ) {
+        $max = 10;
+        return $max;
+}
+
+/**
  * Reduce the spam blokcer limit to 10 emails.
  */
-add_filter('buddypress_messages_spamblocker_10m', 10);
-add_filter('buddypress_messages_spamblocker_30m', 10);
-add_filter('buddypress_messages_spamblocker_60m', 10);
-add_filter('buddypress_messages_spamblocker_12h', 10);
-add_filter('buddypress_messages_spamblocker_24d', 10);
+add_filter( 'buddypress_messages_spamblocker_10m', 'hc_custom_buddypress_messages_spamblocker' );
+add_filter( 'buddypress_messages_spamblocker_30m', 'hc_custom_buddypress_messages_spamblocker' );
+add_filter( 'buddypress_messages_spamblocker_60m', 'hc_custom_buddypress_messages_spamblocker' );
+add_filter( 'buddypress_messages_spamblocker_12h', 'hc_custom_buddypress_messages_spamblocker' );
+add_filter( 'buddypress_messages_spamblocker_24d', 'hc_custom_buddypress_messages_spamblocker' );

--- a/includes/bp-group-documents.php
+++ b/includes/bp-group-documents.php
@@ -15,21 +15,3 @@ function hc_custom_bp_group_documents_email_notification() {
 
 add_action( 'bp_group_documents_add_success' , 'hc_custom_bp_group_documents_email_notification' , 0 ) ;
 
-class BPGroupDocuments {
-
-        const CHECKBOX_NAME = 'group-files-minor-edit';
-
-
-        function __construct() {
-                add_action( 'bp_group_documents_add_success', [ $this, 'prevent_activity' ], 0 );
-        }
-
-        function prevent_activity() {
-                //global $bp_docs;
-                if ( isset( $_POST[ self::CHECKBOX_NAME ] ) ) {
-                    remove_action( 'bp_group_documents_add_success', 'bp_group_documents_record_add' );
-                }
-        }
-}
-
-new BPGroupDocuments;


### PR DESCRIPTION
The filters that were previously there were incorrect as the add_filter function requires a callback for it's second parameter. 

Also removing code that was half finished from the Carol ticket I was working on. 