### PR TITLE
Adding delete button to cv field

### DIFF
--- a/hc-custom.php
+++ b/hc-custom.php
@@ -33,6 +33,7 @@ require_once trailingslashit( __DIR__ ) . 'includes/buddypress-docs.php';
 require_once trailingslashit( __DIR__ ) . 'includes/bp-groupblog.php';
 require_once trailingslashit( __DIR__ ) . 'includes/bp-group-documents.php';
 require_once trailingslashit( __DIR__ ) . 'includes/bp-event-organiser.php';
+require_once trailingslashit( __DIR__ ) . 'includes/bp-attachment-xprofile.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-followers.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-group-email-subscription.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress-more-privacy-options.php';

--- a/includes/bp-attachment-xprofile.php
+++ b/includes/bp-attachment-xprofile.php
@@ -10,6 +10,7 @@
  *
  */
 function hc_custom_delete_file() {
+	check_ajax_referer( 'settings_general_nonce', 'nonce' );
 
 	$file_to_delete = !empty( $_POST[ 'file_to_delete'] ) ? $_POST['file_to_delete'] : '';
 	$field_id_to_delete = !empty( $_POST[ 'field_id_to_delete'] ) ? $_POST['field_id_to_delete'] : '';

--- a/includes/bp-attachment-xprofile.php
+++ b/includes/bp-attachment-xprofile.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Customizations to bp-attachment-xprofile plugin
+ *
+ * @package Hc_Custom
+ */
+
+/**
+ * Delete profile field for the user's profile and delete the file from the filesystem.
+ *
+ */
+function hc_custom_delete_file() {
+
+	$file_to_delete = !empty( $_POST[ 'file_to_delete'] ) ? $_POST['file_to_delete'] : '';
+	$field_id_to_delete = !empty( $_POST[ 'field_id_to_delete'] ) ? $_POST['field_id_to_delete'] : '';
+
+	$root_dir = get_home_path();
+	$webroot_dir = $root_dir . '/web';
+
+	if( !empty($file_to_delete ) ) {
+		xprofile_delete_field_data( $field_id_to_delete, get_current_user_id() );
+		wp_delete_file( dirname(__FILE__, 5) . $file_to_delete );
+	}
+
+ 	die();
+}
+add_action( 'wp_ajax_hc_custom_delete_file', 'hc_custom_delete_file' );
+add_action( 'wp_ajax_nopriv_hc_custom_delete_file', 'hc_custom_delete_file' );


### PR DESCRIPTION
Button is added via javascript in the boss-child theme. 

See: https://trello.com/c/vKbdOKKu/562-determine-what-happened-to-profile-fields-for-linkedin-fb-social-links-twitter-and-orcid-are-still-there