### PR TITLE
Whitelisting string values for fields in xprofile

### DIFF
--- a/hc-custom.php
+++ b/hc-custom.php
@@ -20,6 +20,7 @@ require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-blogs.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-groups.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-members.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-activity.php';
+require_once trailingslashit( __DIR__ ) . 'includes/buddypress/bp-xprofile.php';
 require_once trailingslashit( __DIR__ ) . 'includes/buddypress/buddypress-functions.php';
 
 

--- a/includes/buddypress/bp-xprofile.php
+++ b/includes/buddypress/bp-xprofile.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Customizations to BuddyPress xProfile.
+ *
+ * @package Hc_Custom
+ */
+
+function hc_custom_bp_xprofile_field_type_is_valid( $validated, $values, $instance ) { 
+	
+   if ( is_string ( $values ) && !is_array( $values )  && !empty( $values ) && (false === $validated ) ) {
+	$validated = true;
+   }
+    
+    return $validated; 
+} 
+         
+
+add_filter( 'bp_xprofile_field_type_is_valid', 'hc_custom_bp_xprofile_field_type_is_valid', 10, 3 ); 


### PR DESCRIPTION
the logic in the is_valid function for xprofiles has no condition for a string value, I added a filter to whitelist string for field value. 