### PR TITLE
Adding exceptions for maps group

### DIFF
--- a/includes/buddypress/bp-groups.php
+++ b/includes/buddypress/bp-groups.php
@@ -100,15 +100,17 @@ add_action( 'bp_before_directory_groups_content', 'hcommons_add_non_society_memb
  *  - rename the 'Home' tab to 'Activity'
  */
 function hcommons_override_config_group_nav() {
-		$group_slug = bp_current_item();
-		$group_id = bp_get_current_group_id();
+	$group_slug = bp_current_item();
+	$group_id = bp_get_current_group_id();
 
-		// BP 2.6+.
+	$has_frontpage = ! empty( groups_get_groupmeta( $group_id, 'group_has_frontpage' ) ) ? groups_get_groupmeta( $group_id, 'group_has_frontpage' )  : false;
+
+	// BP 2.6+.
 	if ( function_exists( 'bp_rest_api_init' ) ) {
 			buddypress()->groups->nav->edit_nav( array( 'position' => 1 ), 'forum', $group_slug );
 			buddypress()->groups->nav->edit_nav( array( 'position' => 0 ), 'home', $group_slug );
 
-		      if ( 1003628 == $group_id ) {
+		      if ( $has_frontpage ) {
                            buddypress()->groups->nav->edit_nav( array( 'name' => __( 'Home', 'buddypress' ) ), 'home', $group_slug );
 		      } else {
 			   buddypress()->groups->nav->edit_nav( array( 'name' => __( 'Activity', 'buddypress' ) ), 'home', $group_slug );
@@ -117,7 +119,7 @@ function hcommons_override_config_group_nav() {
 	} else {
 			buddypress()->bp_options_nav[ $group_slug ]['home']['position']  = 0;
 			buddypress()->bp_options_nav[ $group_slug ]['forum']['position'] = 1;
-			buddypress()->bp_options_nav[ $group_slug ]['home']['name']      = __( 'Activitys', 'buddypress' );
+			buddypress()->bp_options_nav[ $group_slug ]['home']['name']      = __( 'Activity', 'buddypress' );
 	}
 }
 
@@ -312,10 +314,6 @@ function hc_custom_get_options_nav( $parent_slug = '' ) {
 		// List type depends on our current component.
 		$list_type = bp_is_group() ? 'groups' : 'personal';
 		
-		if ( 'deposits' === $subnav_item->slug ) {
-			if(  1003628 != $group_id )
-			    continue;
-		}
 
 		if ( 'groups_screen_group_admin' === $subnav_item->screen_function || 'members' === $subnav_item->slug || 'invite-anyone' == $subnav_item->slug || 'notifications' === $subnav_item->slug ) {
                         continue;
@@ -431,7 +429,9 @@ function hc_custom_choose_landing_page() {
 
 	$selected            = groups_get_groupmeta( $group_id, 'group_landing_page' );
 	$secondary_nav_items = $bp->groups->nav->get_secondary( array( 'parent_slug' => $parent_nav_slug ) );
-
+	
+	$has_frontpage = ! empty( groups_get_groupmeta( $group_id, 'group_has_frontpage' ) ) ? groups_get_groupmeta( $group_id, 'group_has_frontpage' )  : false;
+	
 	$html = '';
 
 	if ( isset( $_POST['menu_option_value'] ) && ! empty( $_POST['menu_option_value'] ) ) {
@@ -449,7 +449,7 @@ function hc_custom_choose_landing_page() {
 		$name = preg_replace( '/\d/', '', $subnav_item->name );
 
 		if ( 'Home' === $name ) {
-			if( 1003628 != $group_id ) {
+			if( !$has_frontpage ) {
 			    $name = 'Activity';
 			}
 		}

--- a/includes/buddypress/bp-groups.php
+++ b/includes/buddypress/bp-groups.php
@@ -311,10 +311,15 @@ function hc_custom_get_options_nav( $parent_slug = '' ) {
 	foreach ( $secondary_nav_items as $subnav_item ) :
 		// List type depends on our current component.
 		$list_type = bp_is_group() ? 'groups' : 'personal';
+		
+		if ( 'deposits' === $subnav_item->slug ) {
+			if(  1003628 != $group_id )
+			    continue;
+		}
 
-		if ( 'groups_screen_group_admin' === $subnav_item->screen_function || 'members' === $subnav_item->slug || 'invite-anyone' == $subnav_item->slug || 'notifications' === $subnav_item->slug || 'deposits' === $subnav_item->slug ) {
-			if ( 'deposits' !== $subnav_item->slug && 1003628 !== $group_id )
-			continue;
+		if ( 'groups_screen_group_admin' === $subnav_item->screen_function || 'members' === $subnav_item->slug || 'invite-anyone' == $subnav_item->slug || 'notifications' === $subnav_item->slug ) {
+                        continue;
+
 		}
 
 		$current_status = ! empty( groups_get_groupmeta( $group_id, $subnav_item->slug ) ) ? groups_get_groupmeta( $group_id, $subnav_item->slug ) : '';

--- a/includes/buddypress/bp-groups.php
+++ b/includes/buddypress/bp-groups.php
@@ -60,7 +60,6 @@ add_filter( 'groups_activity_new_update_action', 'hcommons_filter_groups_activit
 function hcommons_add_non_society_member_join_group_button() {
 	if ( ! is_super_admin() && hcommons_check_non_member_active_session() ) {
 		global $groups_template;
-
 		// Set group to current loop group if none passed.
 		if ( empty( $group ) ) {
 			$group =& $groups_template->group;
@@ -101,20 +100,24 @@ add_action( 'bp_before_directory_groups_content', 'hcommons_add_non_society_memb
  */
 function hcommons_override_config_group_nav() {
 		$group_slug = bp_current_item();
+		$group_id = bp_get_current_group_id();
 
 		// BP 2.6+.
 	if ( function_exists( 'bp_rest_api_init' ) ) {
 			buddypress()->groups->nav->edit_nav( array( 'position' => 1 ), 'forum', $group_slug );
 			buddypress()->groups->nav->edit_nav( array( 'position' => 0 ), 'home', $group_slug );
-			buddypress()->groups->nav->edit_nav( array( 'name' => __( 'Activity', 'buddypress' ) ), 'home', $group_slug );
 
+		      if ( 1003628 == $group_id ) {
+                           buddypress()->groups->nav->edit_nav( array( 'name' => __( 'Home', 'buddypress' ) ), 'home', $group_slug );
+		      } else {
+			   buddypress()->groups->nav->edit_nav( array( 'name' => __( 'Activity', 'buddypress' ) ), 'home', $group_slug );
+		      }
 		// Older versions of BP.
 	} else {
 			buddypress()->bp_options_nav[ $group_slug ]['home']['position']  = 0;
 			buddypress()->bp_options_nav[ $group_slug ]['forum']['position'] = 1;
-			buddypress()->bp_options_nav[ $group_slug ]['home']['name']      = __( 'Activity', 'buddypress' );
+			buddypress()->bp_options_nav[ $group_slug ]['home']['name']      = __( 'Activitys', 'buddypress' );
 	}
-
 }
 
 /**
@@ -309,6 +312,7 @@ function hc_custom_get_options_nav( $parent_slug = '' ) {
 		$list_type = bp_is_group() ? 'groups' : 'personal';
 
 		if ( 'groups_screen_group_admin' === $subnav_item->screen_function || 'members' === $subnav_item->slug || 'invite-anyone' == $subnav_item->slug || 'notifications' === $subnav_item->slug || 'deposits' === $subnav_item->slug ) {
+			if ( 'deposits' !== $subnav_item->slug && 1003628 !== $group_id )
 			continue;
 		}
 

--- a/includes/buddypress/bp-groups.php
+++ b/includes/buddypress/bp-groups.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
  * Customizations to BuddyPress Groups.
@@ -443,7 +444,9 @@ function hc_custom_choose_landing_page() {
 		$name = preg_replace( '/\d/', '', $subnav_item->name );
 
 		if ( 'Home' === $name ) {
-			$name = 'Activity';
+			if( 1003628 != $group_id ) {
+			    $name = 'Activity';
+			}
 		}
 
 		if ( 'hide' === groups_get_groupmeta( $group_id, $subnav_item->slug ) ) {


### PR DESCRIPTION
This adds exceptions for the Maps group so that you can hide core deposits and make the Home page the default page the user gets to.

Changed to get group meta. Note that you'll have to use groups_update_groupmeta, not raw sql , because it checks cache, it doesnt do a sql query. 

`groups_update_groupmeta( $group_id, 'group_has_frontpage', 1)`