### PR TITLE
Fixing class not found error when disabling site origin plugin

### DIFF
--- a/includes/siteorigin-panels.php
+++ b/includes/siteorigin-panels.php
@@ -11,7 +11,9 @@
  */
 function hc_remove_siteorigin_register_widgets_on_docs() {
 	if ( isset( $_SERVER['REQUEST_URI'] ) && false !== strpos( $_SERVER['REQUEST_URI'], '/docs/' ) ) {
-		remove_action( 'widgets_init', array( SiteOrigin_Panels_Sidebars_Emulator::single(), 'register_widgets' ), 99 );
+	    if (class_exists('SiteOrigin_Panels_Sidebars_Emulator')) {
+	        remove_action( 'widgets_init', array( SiteOrigin_Panels_Sidebars_Emulator::single(), 'register_widgets' ), 99 );
+	    }
 	}
 }
 add_action( 'widgets_init', 'hc_remove_siteorigin_register_widgets_on_docs' );


### PR DESCRIPTION
Adding if class exists check. 