### PR TITLE
update hc_custom_bp_show_blog_signup_form for BP 9.0.0 compatibility

### DIFF
--- a/includes/buddypress/buddypress-functions.php
+++ b/includes/buddypress/buddypress-functions.php
@@ -56,8 +56,8 @@ function hc_custom_bp_show_blog_signup_form($blogname = '', $blog_title = '', $e
         }
     } 
     
-    if ( ! isset( $_POST['submit'] ) || false === $blog_id || is_wp_error( $blog_id ) ) {
-        if ( is_wp_error( $blog_id ) ) {
+    if ( ! isset( $_POST['submit'] ) || ! isset( $blog_id ) || false === $blog_id || is_wp_error( $blog_id ) ) {
+        if ( isset( $blog_id ) && is_wp_error( $blog_id ) ) {
 			$errors = $blog_id;
 		} elseif ( ! is_wp_error($errors) ) {
             $errors = new WP_Error();


### PR DESCRIPTION
In BP 9.0.0, ```bp_blogs_validate_blog_signup``` no longer calls ```bp_blogs_confirm_blog_signup``` itself, but instead returns the blog_id of the newly-created blog. ```hc_custom_bp_show_blog_signup_form``` needed to be updated to call ```bp_blogs_confirm_blog_signup``` upon successful validation.

The function was also updated to follow the logic of the current version of ```bp_show_blog_signup_form```.

This should fix the problem where the confirmation message fails to appear. There might be a separate issue of blogs not being created.